### PR TITLE
Add Mardown support to Description field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.pyc
 local_settings.py
 *.db
+venv
+*.sqlite3
+dojopuzzles/static/*
+.vscode

--- a/dojopuzzles/dojopuzzles/settings.py
+++ b/dojopuzzles/dojopuzzles/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "core",
     "problems",
+    "markdownx",
 ]
 
 MIDDLEWARE = [

--- a/dojopuzzles/dojopuzzles/urls.py
+++ b/dojopuzzles/dojopuzzles/urls.py
@@ -19,5 +19,6 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("problems/", include("problems.urls")),
+    path("markdownx/", include("markdownx.urls")),
     path("", include("core.urls")),
 ]

--- a/dojopuzzles/problems/admin.py
+++ b/dojopuzzles/problems/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
+from markdownx.admin import MarkdownxModelAdmin
 
 from problems.models import Problem
 
-admin.site.register(Problem)
+admin.site.register(Problem, MarkdownxModelAdmin)

--- a/dojopuzzles/problems/models.py
+++ b/dojopuzzles/problems/models.py
@@ -2,7 +2,8 @@ from django.db import models
 from django.utils.text import slugify
 
 from problems.managers import ProblemManager
-
+from markdownx.models import MarkdownxField
+from markdownx.utils import markdownify
 
 class SelectUnpublishedProblemException(Exception):
     ...
@@ -11,7 +12,7 @@ class SelectUnpublishedProblemException(Exception):
 class Problem(models.Model):
     title = models.CharField(max_length=100, blank=False)
     slug = models.CharField(max_length=100, blank=False)
-    description = models.TextField(blank=False)
+    description = MarkdownxField(blank=False)
     author = models.CharField(max_length=100, blank=True, null=True)
     published = models.BooleanField(default=False)
     uses = models.IntegerField(default=0)
@@ -34,6 +35,9 @@ class Problem(models.Model):
         if not self.slug:
             self.slug = slugify(self.title)
         super().save(*args, **kwargs)
+
+    def formatted_description(self):
+        return markdownify(self.description)
 
     def select(self):
         """ Problem is selected for Coding Dojo """

--- a/dojopuzzles/problems/templates/problems/details.html
+++ b/dojopuzzles/problems/templates/problems/details.html
@@ -29,7 +29,7 @@
 
         <div id="descricao_problema">
             {% autoescape off %}
-                {{ problem.description }}
+                {{ problem.formatted_description }}
             {% endautoescape %}
         </div>
     </div>

--- a/requirements
+++ b/requirements
@@ -1,1 +1,2 @@
 Django==3.1
+django-markdownx==3.0.1


### PR DESCRIPTION
Solves #32 using [django-markdownx](https://pypi.org/project/django-markdownx/)

MarkdownX offers a ton of customization options, but I thought it would be better to keep it simple by now, so it's customized later based on demand.
