### PR TITLE
redirect urls with old format to new one

### DIFF
--- a/dojopuzzles/dojopuzzles/urls.py
+++ b/dojopuzzles/dojopuzzles/urls.py
@@ -19,5 +19,6 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("problems/", include("problems.urls")),
+    path("problemas/", include("problems.old_urls")),
     path("", include("core.urls")),
 ]

--- a/dojopuzzles/problems/old_urls.py
+++ b/dojopuzzles/problems/old_urls.py
@@ -1,0 +1,13 @@
+# handles the old routes and match them to views that redirects to new urls format
+from django.urls import path
+
+from problems import oldurlstonew_views as views
+
+urlpatterns = [
+    path("exibe/random/", views.problem_random_redirect),
+    path(
+        "exibe/select/<int:problem_id>",
+        views.problem_select_redirect,
+    ),
+    path("exibe/<slug:slug>/", views.problem_details_redirect),
+]

--- a/dojopuzzles/problems/oldurlstonew_views.py
+++ b/dojopuzzles/problems/oldurlstonew_views.py
@@ -1,0 +1,14 @@
+# views to redirect old urls format to new ones.
+from django.shortcuts import redirect
+
+
+def problem_details_redirect(request, slug):
+    return redirect("problems:problem_details", slug=slug)
+
+
+def problem_random_redirect(request):
+    return redirect("problems:problem_random")
+
+
+def problem_select_redirect(request, problem_id):
+    return redirect("problems:problem_select", problem_id=problem_id)


### PR DESCRIPTION
I have created two files inside `problems` app, `old_urls.py` and `oldurlstonew_views.py`.
`old_urls.py` takes the old urls and send them to appropriate view in `oldurlstonew_views.py` which redirects them to new url format along with slug or problem_id if present.

fixes #50 